### PR TITLE
Refactor controller y service

### DIFF
--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/bootstrap/helper.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/bootstrap/helper.kt
@@ -136,6 +136,7 @@ fun eventAdrian(creatorEmployee: Employee, participantsEmployees:Set<Employee>):
         date = LocalDateTime.now().plus(1, ChronoUnit.DAYS)
         creator = creatorEmployee
         participants = participantsEmployees.toMutableSet()
+        public = true
     }
 }
 

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/controller/EventController.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/controller/EventController.kt
@@ -3,15 +3,18 @@ package ar.edu.unsam.proyecto_de_sofware.event_nexus.controller
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.EventDTO
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.ShowEventDTO
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.showEventDTO
+import ar.edu.unsam.proyecto_de_sofware.event_nexus.exceptions.DataBaseNotModifiedException
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.Employee
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.modules.base.events.Event
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.service.EventService
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.service.UserService
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -27,7 +30,7 @@ class EventController(
 ) {
     @GetMapping()
     fun events(): List<ShowEventDTO> {
-        return eventService.events().map { it.showEventDTO() }
+        return eventService.findAllByPublic().map { it.showEventDTO() }
     }
 
     @GetMapping("/{id}")
@@ -38,23 +41,11 @@ class EventController(
         return mapOf("createdEvents" to createdEvents, "invitedEvents" to invitedEvents)
     }
 
-    @GetMapping("/{id}/created")
-    fun createdEvents(@PathVariable id: Long): List<Event> {
-        val employee: Employee = userService.getByID(id)
-        return eventService.employeeCreatedEvents(employee)
-    }
-
-    @GetMapping("{id}/invited")
-    fun invitedEvents(@PathVariable id: Long): List<Event> {
-        val employee: Employee = userService.getByID(id)
-        return eventService.employeeInvitedEvents(employee)
-    }
 
     @PostMapping("/create")
     fun createEvent(@RequestBody newEventDTO: EventDTO): ResponseEntity<String> {
         val creatorEmployee = userService.getByID(newEventDTO.creatorId)
         val participantsEmployees = userService.findAllById(employeesIds = newEventDTO.participantsIds.toList())
-
         val newEvent = Event().apply {
             creator = creatorEmployee
             participants = participantsEmployees.toMutableSet()
@@ -68,22 +59,36 @@ class EventController(
         return ResponseEntity.ok().body("Evento creado!")
     }
 
-    @PostMapping("/join")
-    fun joinEvent(@RequestParam employeeId: Long, @RequestParam eventId: Long): ResponseEntity<String> {
-        val employee = userService.getByID(employeeId)
-        val event = eventService.getById(eventId)
-        event.addParticipant(employee)
-        eventService.updateEvent(event)
-        return ResponseEntity.ok().body("Te uniste al evento!")
-    }
-
-    @PostMapping("/leave")
+    @PostMapping("/join-leave")
     fun leaveEvent(@RequestParam employeeId: Long, @RequestParam eventId: Long): ResponseEntity<String> {
         val employee: Employee = userService.getByID(employeeId)
         val event: Event = eventService.getById(eventId)
+        eventService.joinLeave(event, employee)
         event.removeParticipant(employee)
-        eventService.updateEvent(event)
-        return ResponseEntity.ok().body("Abandonaste el evento!")
+        try{
+            eventService.updateEvent(event)
+        }catch (e: DataBaseNotModifiedException){
+            return ResponseEntity
+                .status(HttpStatus.NOT_MODIFIED)
+                .body(e.message)
+        }
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body("Actualizacion exitosa!")
     }
 
+    @PutMapping()
+    fun modify(@RequestBody eventDTO: EventDTO): ResponseEntity<String>{
+        val event = eventService.getById(eventDTO.id)
+        try{
+            eventService.modify(event, eventDTO)
+        }catch (e: DataBaseNotModifiedException){
+            return ResponseEntity
+                .status(HttpStatus.NOT_MODIFIED)
+                .body(e.message)
+        }
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body("Actualizacion exitosa!")
+    }
 }

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/controller/EventController.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/controller/EventController.kt
@@ -78,8 +78,8 @@ class EventController(
     }
 
     @PutMapping()
-    fun modify(@RequestBody eventDTO: EventDTO): ResponseEntity<String>{
-        val event = eventService.getById(eventDTO.id)
+    fun modify(@RequestBody eventDTO: ShowEventDTO): ResponseEntity<String>{
+        val event = eventService.getById(eventDTO.id!!)
         try{
             eventService.modify(event, eventDTO)
         }catch (e: DataBaseNotModifiedException){

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/controller/EventController.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/controller/EventController.kt
@@ -11,6 +11,7 @@ import ar.edu.unsam.proyecto_de_sofware.event_nexus.service.UserService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -54,17 +55,16 @@ class EventController(
             description = newEventDTO.description
             dateFinished = newEventDTO.date
         }
-//        creatorEmployee.canDoModuleAction(command=CreateEvent())
+//      creatorEmployee.canDoModuleAction(command=CreateEvent())
         eventService.createEvent(newEvent, creatorEmployee)
         return ResponseEntity.ok().body("Evento creado!")
     }
 
     @PostMapping("/join-leave")
-    fun leaveEvent(@RequestParam employeeId: Long, @RequestParam eventId: Long): ResponseEntity<String> {
+    fun joinLeave(@RequestParam employeeId: Long, @RequestParam eventId: Long): ResponseEntity<String> {
         val employee: Employee = userService.getByID(employeeId)
         val event: Event = eventService.getById(eventId)
         eventService.joinLeave(event, employee)
-        event.removeParticipant(employee)
         try{
             eventService.updateEvent(event)
         }catch (e: DataBaseNotModifiedException){
@@ -90,5 +90,21 @@ class EventController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body("Actualizacion exitosa!")
+    }
+
+    @DeleteMapping()
+    fun delete(@RequestParam employeeId: Long, @RequestParam eventId: Long): ResponseEntity<String>{
+        val event = eventService.getById(eventId)
+        val employee = userService.getByID(employeeId)
+        try{
+            eventService.delete(event, employee)
+        }catch (error: DataBaseNotModifiedException){
+            return ResponseEntity
+                .status(HttpStatus.NOT_MODIFIED)
+                .body(error.message)
+        }
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body("Evento eliminado")
     }
 }

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/controller/UserController.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/controller/UserController.kt
@@ -1,10 +1,13 @@
 package ar.edu.unsam.proyecto_de_sofware.event_nexus.controller
 
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.*
+import ar.edu.unsam.proyecto_de_sofware.event_nexus.exceptions.BusinessException
+import ar.edu.unsam.proyecto_de_sofware.event_nexus.exceptions.DataBaseNotModifiedException
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.Employee
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.service.AuthService
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.service.UserService
 import jakarta.websocket.server.PathParam
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
@@ -37,12 +40,30 @@ class UserController(private val userService: UserService) {
 
     @PutMapping("profile")
     fun profileUpdate(@RequestBody dataUpdateProfileDTO: DataUpdateProfileDTO): ResponseEntity<String>{
-        return userService.updateProfile(dataUpdateProfileDTO)
+        try{
+            userService.updateProfile(dataUpdateProfileDTO)
+        }catch (error: DataBaseNotModifiedException){
+            ResponseEntity
+                .status(HttpStatus.NOT_MODIFIED)
+                .body(error.message)
+        }
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body("Actualizacion exitosa!")
     }
 
     @PutMapping("/img")
     fun changeImg(@RequestBody imgDTO: ImgDTO): ResponseEntity<String>{
         val user = userService.getByID(imgDTO.id)
-        return userService.changeImg(user, imgDTO.img)
+        try {
+            userService.changeImg(user, imgDTO.img)
+        }catch (error: DataBaseNotModifiedException){
+            return ResponseEntity
+                .status(HttpStatus.NOT_MODIFIED)
+                .body(error.message)
+        }
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body("Actualizacion exitosa!")
     }
 }

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/dto/EventDTO.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/dto/EventDTO.kt
@@ -4,6 +4,7 @@ import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.modules.base.events.Ev
 import java.time.LocalDateTime
 
 data class EventDTO(
+    val id: Long,
     val creatorId: Long,
     val participantsIds: MutableSet<Long>,
     val date: LocalDateTime,

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/exceptions/ExceptionMock.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/exceptions/ExceptionMock.kt
@@ -3,7 +3,7 @@ package ar.edu.unsam.proyecto_de_sofware.event_nexus.exceptions
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
-@ResponseStatus(HttpStatus.NOT_FOUND)
+@ResponseStatus(HttpStatus.NOT_FOUND) //TODO aca no tendria que ser un NOT_FOUND
 class BusinessException(override val message:String): Exception(message)
 
 @ResponseStatus(HttpStatus.NOT_MODIFIED)

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/model/modules/base/events/Event.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/model/modules/base/events/Event.kt
@@ -72,14 +72,14 @@ class Event(){
     fun isPending() : Boolean = date > LocalDateTime.now()
 
     fun fromDTO(eventDTO: EventDTO){
-        if(!canModify(eventDTO.creatorId)){
+        if(!isCreator(eventDTO.creatorId)){
             throw BusinessException("No puede modificar este evento")
         }
         date = eventDTO.date
         description = eventDTO.description
     }
 
-    fun canModify(employeeId: Long): Boolean{
-        return employeeId == id
+    fun isCreator(employeeId: Long): Boolean{
+        return employeeId == creator.id
     }
 }

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/model/modules/base/events/Event.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/model/modules/base/events/Event.kt
@@ -1,6 +1,7 @@
 package ar.edu.unsam.proyecto_de_sofware.event_nexus.model.modules.base.events
 
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.EventDTO
+import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.ShowEventDTO
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.exceptions.BusinessException
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.Employee
 import jakarta.persistence.Column
@@ -71,12 +72,13 @@ class Event(){
 
     fun isPending() : Boolean = date > LocalDateTime.now()
 
-    fun fromDTO(eventDTO: EventDTO){
-        if(!isCreator(eventDTO.creatorId)){
+    fun fromDTO(eventDTO: ShowEventDTO){
+        if(!isCreator(eventDTO.creatorId!!)){
             throw BusinessException("No puede modificar este evento")
         }
-        date = eventDTO.date
+        date = eventDTO.dateFinished
         description = eventDTO.description
+        title = eventDTO.title
     }
 
     fun isCreator(employeeId: Long): Boolean{

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/model/modules/base/events/Event.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/model/modules/base/events/Event.kt
@@ -1,5 +1,7 @@
 package ar.edu.unsam.proyecto_de_sofware.event_nexus.model.modules.base.events
 
+import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.EventDTO
+import ar.edu.unsam.proyecto_de_sofware.event_nexus.exceptions.BusinessException
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.Employee
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -42,6 +44,9 @@ class Event(){
     @Column
     var description: String = ""
 
+    @Column
+    var public: Boolean = false
+
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
         name="employee_event",
@@ -60,5 +65,21 @@ class Event(){
         this.participants.remove(participant)
     }
 
+    fun employeeParticipates(participant: Employee): Boolean{
+        return  participants.contains(participant)
+    }
+
     fun isPending() : Boolean = date > LocalDateTime.now()
+
+    fun fromDTO(eventDTO: EventDTO){
+        if(!canModify(eventDTO.creatorId)){
+            throw BusinessException("No puede modificar este evento")
+        }
+        date = eventDTO.date
+        description = eventDTO.description
+    }
+
+    fun canModify(employeeId: Long): Boolean{
+        return employeeId == id
+    }
 }

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/repository/EventRepository.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/repository/EventRepository.kt
@@ -2,11 +2,15 @@ package ar.edu.unsam.proyecto_de_sofware.event_nexus.repository
 
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.Employee
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.modules.base.events.Event
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
+import org.springframework.web.bind.annotation.PathVariable
 
 interface EventRepository: CrudRepository<Event, Long> {
 
     fun findByCreator(creator: Employee): List<Event>
 
     fun findByParticipants(participant: Employee): List<Event>
+
+    fun findAllByPublic(public: Boolean = true): List<Event>
 }

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/service/EventService.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/service/EventService.kt
@@ -68,4 +68,16 @@ class EventService(
             event.addParticipant(employee)
         }
     }
+
+    fun delete(event: Event, employee: Employee) {
+        if(event.isCreator(employee.id!!)){
+            try {
+                eventRepository.delete(event)
+            }catch (error: DataAccessException){
+                throw DataBaseNotModifiedException("No se puede eliminar")
+            }
+        }else{
+            throw BusinessException("No eres el creador del evento")
+        }
+    }
 }

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/service/EventService.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/service/EventService.kt
@@ -1,14 +1,19 @@
 package ar.edu.unsam.proyecto_de_sofware.event_nexus.service
 
+import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.EventDTO
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.ShowEventDTO
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.showEventDTO
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.exceptions.BusinessException
+import ar.edu.unsam.proyecto_de_sofware.event_nexus.exceptions.DataBaseNotModifiedException
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.Employee
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.modules.base.events.Event
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.repository.EventRepository
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.dao.DataAccessException
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -20,8 +25,8 @@ class EventService(
         return eventRepository.findById(eventId).orElseThrow{ BusinessException("No se encontro Evento")}
     }
 
-    fun events(): List<Event> {
-        return eventRepository.findAll().toList()
+    fun findAllByPublic(): List<Event> {
+        return eventRepository.findAllByPublic()
     }
 
     fun employeeCreatedEvents(employee: Employee): List<Event> {
@@ -37,7 +42,7 @@ class EventService(
         try {
             eventRepository.save(event)
         } catch (e: DataAccessException) {
-            throw RuntimeException("No se pudo actualizar eventos") //TODO hacer custom
+            throw RuntimeException("No se pudo actualizar eventos")
         }
     }
 
@@ -46,7 +51,21 @@ class EventService(
         try {
             eventRepository.save(event)
         } catch (e: DataAccessException) {
-            throw RuntimeException("No se pudo actualizar eventos") //TODO hacer custom
+            throw DataBaseNotModifiedException("No se pudo actualizar eventos")
+        }
+    }
+
+    @Transactional
+    fun modify(event: Event, eventDTO: EventDTO) {
+        event.fromDTO(eventDTO)
+        return updateEvent(event)
+    }
+
+    fun joinLeave(event: Event, employee: Employee) {
+        if(event.employeeParticipates(employee)){
+            event.removeParticipant(employee)
+        }else{
+            event.addParticipant(employee)
         }
     }
 }

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/service/EventService.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/service/EventService.kt
@@ -56,7 +56,7 @@ class EventService(
     }
 
     @Transactional
-    fun modify(event: Event, eventDTO: EventDTO) {
+    fun modify(event: Event, eventDTO: ShowEventDTO) {
         event.fromDTO(eventDTO)
         return updateEvent(event)
     }

--- a/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/service/UserService.kt
+++ b/src/main/kotlin/ar/edu/unsam/proyecto_de_sofware/event_nexus/service/UserService.kt
@@ -2,6 +2,7 @@ package ar.edu.unsam.proyecto_de_sofware.event_nexus.service
 
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.DataUpdateProfileDTO
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.dto.ImgDTO
+import ar.edu.unsam.proyecto_de_sofware.event_nexus.exceptions.BusinessException
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.exceptions.DataBaseNotModifiedException
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.model.Employee
 import ar.edu.unsam.proyecto_de_sofware.event_nexus.repository.UserRepository
@@ -10,40 +11,34 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.client.HttpClientErrorException.NotFound
 
 @Service
 class UserService(val repoUser: UserRepository) {
 
     fun getByID(id : Long): Employee {
-        val user = repoUser.findById(id)
-        return user.get()
+        return repoUser.findById(id).orElseThrow{throw BusinessException("Usuario no encontrado")}
     }
 
     @Transactional
-    fun updateProfile(dataUpdateProfileDTO: DataUpdateProfileDTO) : ResponseEntity<String> {
+    fun updateProfile(dataUpdateProfileDTO: DataUpdateProfileDTO) {
         val user = repoUser.findById(dataUpdateProfileDTO.id).get()
         user.updateProfile(dataUpdateProfileDTO)
         try {
             repoUser.save(user)
-        }catch (e: DataAccessException){
+        } catch (e: DataAccessException) {
             throw DataBaseNotModifiedException("No se pudo actualizar el perfil")
         }
-        return ResponseEntity
-            .status(HttpStatus.OK)
-            .body("Actualizacion exitosa!")
     }
 
     @Transactional
-    fun changeImg(user: Employee, img: String): ResponseEntity<String> {
+    fun changeImg(user: Employee, img: String){
         user.image = img
         try {
             repoUser.save(user)
         }catch (error: DataAccessException){
             throw DataBaseNotModifiedException("No se pudo actualizar el perfil")
         }
-        return ResponseEntity
-            .status(HttpStatus.OK)
-            .body("Actualizacion exitosa!")
     }
 
 


### PR DESCRIPTION
## Descripción
Se realiza un refactor general. Se trata de devolcer siempre una response entity y manerar los runtime exception
Se borran controlers inutiles
Queda el tema de los dto de usuario que lo van a tener que definir los chicos del front
Ya se puede
1) unir o salir de un evento
2) moficar evento
3) eliminar evento
4) crear evento
